### PR TITLE
Lazy-load DevTools component

### DIFF
--- a/src/ui/options/advanced/advanced-tab.tsx
+++ b/src/ui/options/advanced/advanced-tab.tsx
@@ -23,7 +23,7 @@ export function AdvancedTab(props: ViewProps): Malevic.Child {
         });
     }
 
-    const DevTools = store.DevTools;
+    const {DevTools} = store;
 
     return <div class="settings-tab">
         <SyncSettings {...props} />

--- a/src/ui/options/advanced/advanced-tab.tsx
+++ b/src/ui/options/advanced/advanced-tab.tsx
@@ -1,9 +1,10 @@
 import {m} from 'malevic';
+import {getContext} from 'malevic/dom';
 
 import type {ViewProps} from '../../../definitions';
 
 import {ContextMenus} from './context-menus';
-import {DevTools} from './devtools';
+import type {DevTools as DevToolsType} from './devtools';
 import {EnableForProtectedPages} from './enable-for-protected-pages';
 import {ExportSettings} from './export-settings';
 import {ImportSettings} from './import-settings';
@@ -12,6 +13,18 @@ import {SyncConfig} from './sync-config';
 import {SyncSettings} from './sync-settings';
 
 export function AdvancedTab(props: ViewProps): Malevic.Child {
+    const context = getContext();
+    const store = context.getStore<{DevTools?: typeof DevToolsType}>({});
+
+    if (!store.DevTools) {
+        import('./devtools').then((mod) => {
+            store.DevTools = mod.DevTools;
+            context.refresh();
+        });
+    }
+
+    const DevTools = store.DevTools;
+
     return <div class="settings-tab">
         <SyncSettings {...props} />
         <SyncConfig {...props} />
@@ -20,6 +33,6 @@ export function AdvancedTab(props: ViewProps): Malevic.Child {
         <ImportSettings {...props} />
         <ExportSettings {...props} />
         <ResetSettings {...props} />
-        <DevTools />
+        {DevTools ? <DevTools /> : null}
     </div>;
 }


### PR DESCRIPTION
## Summary
- load DevTools component only when Advanced tab is rendered
- avoid bundling DevTools into the initial options chunk

## Testing
- `npm test`

## Summary by Sourcery

Lazy-load the DevTools component in AdvancedTab to defer bundling until the tab is opened and reduce the initial options chunk size.

Enhancements:
- Dynamically import DevTools when AdvancedTab mounts
- Conditionally render DevTools only after it has been loaded