### PR TITLE
Add preconnect link in HTML bundler

### DIFF
--- a/tasks/bundle-html.js
+++ b/tasks/bundle-html.js
@@ -24,6 +24,7 @@ function html(platform, title, hasLoader, hasStyleSheet) {
         ...(hasStyleSheet ? [
             '        <meta name="theme-color" content="#0B2228" />',
             '        <meta name="viewport" content="width=device-width, initial-scale=1" />',
+            '        <link rel="preconnect" href="https://darkreader.org" />',
             '        <link rel="stylesheet" type="text/css" href="style.css" />',
             '        <link',
             '            rel="shortcut icon"',


### PR DESCRIPTION
## Summary
- inject a `<link rel="preconnect" href="https://darkreader.org">` into HTML pages when a stylesheet is present

## Testing
- `npm test`
- `node -` to generate HTML with the new preconnect link