### PR TITLE
Refactor manifest access

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,6 +4,7 @@ import {getHelpURL, UNINSTALL_URL} from '../utils/links';
 import {emulateColorScheme, isSystemDarkModeEnabled} from '../utils/media-query';
 import {DebugMessageTypeBGtoCS, DebugMessageTypeBGtoUI, DebugMessageTypeCStoBG} from '../utils/message';
 import {isFirefox} from '../utils/platform';
+import {MANIFEST} from '../utils/manifest';
 
 import {Extension} from './extension';
 import {makeChromiumHappy} from './make-chromium-happy';
@@ -181,8 +182,7 @@ if (__TEST__) {
                     Extension.collectData().then(respond);
                     break;
                 case 'getManifest': {
-                    const data = chrome.runtime.getManifest();
-                    respond(data);
+                    respond(MANIFEST);
                     break;
                 }
                 case 'changeChromeStorage': {
@@ -265,7 +265,7 @@ function writeInstallationVersion(
         storage.set({installation: {
             date: Date.now(),
             reason: details.reason,
-            version: details.previousVersion ?? chrome.runtime.getManifest().version,
+            version: details.previousVersion ?? MANIFEST.version,
         }});
     });
 }

--- a/src/ui/options/about/version.tsx
+++ b/src/ui/options/about/version.tsx
@@ -1,12 +1,13 @@
 import {m} from 'malevic';
 
 import {getLocalMessage} from '../../../utils/locales';
+import {MANIFEST} from '../../../utils/manifest';
 
 let appVersion: string;
 
 export function AppVersion(): Malevic.Child {
     if (!appVersion) {
-        appVersion = chrome.runtime.getManifest().version;
+        appVersion = MANIFEST.version;
     }
     return (
         <label class="darkreader-version">{getLocalMessage('version')} {appVersion}</label>

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -1,0 +1,1 @@
+export const MANIFEST = chrome.runtime.getManifest();


### PR DESCRIPTION
## Summary
- centralize `chrome.runtime.getManifest()` in `src/utils/manifest.ts`
- replace direct calls with `MANIFEST` constant

## Testing
- `npx eslint src/background/index.ts src/ui/options/about/version.tsx src/utils/manifest.ts`
- `npm test`

## Summary by Sourcery

Centralize access to the extension manifest by exporting a MANIFEST constant from a new utility module and update all code to use this constant instead of direct chrome.runtime.getManifest() calls.

Enhancements:
- Export MANIFEST constant from src/utils/manifest.ts to provide a single source for manifest data
- Replace direct chrome.runtime.getManifest() calls with MANIFEST references in background processes and the options UI version component